### PR TITLE
Add producer reconnect when timeout

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -125,6 +125,20 @@ final class Connection implements IConnection
 		}
 	}
 
+	public function reconnect(): void
+	{
+		$this->bunnyClient->syncDisconnect(); // close current connection to get rid of error on script exit - destructor
+
+		$this->bunnyClient = $this->createNewConnection();
+		$this->bunnyClient->connect();
+		$channel = $this->bunnyClient->channel();
+
+		if (!$channel instanceof Channel) {
+			throw new \UnexpectedValueException;
+		}
+
+		$this->channel = $channel;
+	}
 
 	private function createNewConnection(): Client
 	{

--- a/src/Connection/IConnection.php
+++ b/src/Connection/IConnection.php
@@ -20,4 +20,6 @@ interface IConnection
 	 * @throws BunnyException
 	 */
 	public function sendHeartbeat(): void;
+
+	public function reconnect(): void;
 }

--- a/src/Producer/Producer.php
+++ b/src/Producer/Producer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Contributte\RabbitMQ\Producer;
 
+use Bunny\Exception\ClientException;
 use Contributte\RabbitMQ\Exchange\IExchange;
 use Contributte\RabbitMQ\Queue\IQueue;
 
@@ -39,18 +40,19 @@ final class Producer
 
 	public function publish(string $message, array $headers = [], ?string $routingKey = null): void
 	{
-		$headers = array_merge($this->getBasicHeaders(), $headers);
+		try {
+			$this->sendPublish(...func_get_args());
+		} catch (ClientException $e) {
+			if (!in_array(
+				$e->getMessage(),
+				['Broken pipe or closed connection.', 'Could not write data to socket.'],
+				true
+			)) {
+				throw $e;
+			}
+			$this->reconnect();
 
-		if ($this->queue !== null) {
-			$this->publishToQueue($message, $headers);
-		}
-
-		if ($this->exchange !== null) {
-			$this->publishToExchange($message, $headers, $routingKey ?? '');
-		}
-
-		foreach ($this->publishCallbacks as $callback) {
-			($callback)($message, $headers, $routingKey);
+			$this->sendPublish(...func_get_args());
 		}
 	}
 
@@ -68,6 +70,34 @@ final class Producer
 		}
 		if ($this->exchange !== null) {
 			$this->exchange->getConnection()->sendHeartbeat();
+		}
+	}
+
+
+	private function reconnect(): void
+	{
+		if ($this->queue !== null) {
+			$this->queue->getConnection()->reconnect();
+		} elseif ($this->exchange !== null) {
+			$this->exchange->getConnection()->reconnect();
+		}
+	}
+
+
+	private function sendPublish(string $message, array $headers = [], ?string $routingKey = null): void
+	{
+		$headers = array_merge($this->getBasicHeaders(), $headers);
+
+		if ($this->queue !== null) {
+			$this->publishToQueue($message, $headers);
+		}
+
+		if ($this->exchange !== null) {
+			$this->publishToExchange($message, $headers, $routingKey ?? '');
+		}
+
+		foreach ($this->publishCallbacks as $callback) {
+			($callback)($message, $headers, $routingKey);
 		}
 	}
 


### PR DESCRIPTION
This pull request fix situation when is called publish and then script waiting or processing something else (without hearthbeat to rabbitmq) and then (after long time) is called another publish that failes on error like "Could not write data to socket." or "Broken pipe or closed connection.".